### PR TITLE
fix: 动态分支节点,流程变量属性获取为null，导致无法部署

### DIFF
--- a/uflo-console-js/src/designer/ForeachNode.js
+++ b/uflo-console-js/src/designer/ForeachNode.js
@@ -15,6 +15,7 @@ export default class ForeachNode  extends BaseNode{
         const nodeProps=this.getXMLNodeBaseProps(json);
         let xml=`<${nodeName} ${nodeProps}`;
         xml+=` foreach-type="${this.foreachType}"`;
+        xml+=` var="${this.variable}"`;
         if(this.foreachType==='In'){
             xml+=` process-variable="${this.processVariable}"`;
         }else{

--- a/uflo-core/src/main/java/com/bstek/uflo/deploy/validate/impl/ForeachNodeValidator.java
+++ b/uflo-core/src/main/java/com/bstek/uflo/deploy/validate/impl/ForeachNodeValidator.java
@@ -40,7 +40,8 @@ public class ForeachNodeValidator extends NodeValidator {
 			errors.add("动态分支节点的集合类型变量来源属性不能为空");			
 		}else{
 			ForeachType foreachType=ForeachType.valueOf(type);
-			if(foreachType.equals(ForeachType.In) && StringUtils.isEmpty(element.getAttribute("in"))){
+			//if(foreachType.equals(ForeachType.In) && StringUtils.isEmpty(element.getAttribute("in"))){
+			if(foreachType.equals(ForeachType.In) && StringUtils.isEmpty(element.getAttribute("process-variable"))){
 				errors.add("动态分支节点的集合类型变量来源为流程变量时，流程变量属性不能为空");							
 			}
 			if(foreachType.equals(ForeachType.Handler) && StringUtils.isEmpty(element.getAttribute("handler-bean"))){


### PR DESCRIPTION
前台返回流程变量属性key值为process-variable,后台判断获取key值为in
NodeValidator校验失败，无法部署
element.getAttribute("in")改为element.getAttribute("process-variable")